### PR TITLE
Publish all artifacts

### DIFF
--- a/.github/workflows/publish_main_snapshot.yml
+++ b/.github/workflows/publish_main_snapshot.yml
@@ -20,4 +20,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew build publishMavenJavaPublicationToMavenRepository
+        run: ./gradlew build publish

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -21,4 +21,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew build publishMavenJavaPublicationToMavenRepository -Prelease=true
+        run: ./gradlew build publish -Prelease=true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ group = "com.newrelic.agent.java"
 // -Prelease=true will render a non-snapshot version
 // All other values (including unset) will render a snapshot version.
 val release: String? by project
-version = "3.1" + if("true" == release) "" else "-SNAPSHOT"
+version = "3.2" + if("true" == release) "" else "-SNAPSHOT"
 
 tasks.jar {
     from ("LICENSE")
@@ -72,40 +72,50 @@ publishing {
             }
         }
     }
-    publications {
-        register("mavenJava", MavenPublication::class) {
-            from(components["java"])
-            pom {
-                name.set(project.name)
-                description.set("Verifies instrumentation applies to library version")
-                url.set("https://github.com/newrelic/newrelic-gradle-verify-instrumentation")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                        distribution.set("repo")
+    // afterEvaluate is necessary because java-gradle-plugin
+    // creates its publications in an afterEvaluate callback
+    afterEvaluate {
+        publications {
+            register("mavenJava", MavenPublication::class) {
+                from(components["java"])
+            }
+            // customize all publications here
+            withType(MavenPublication::class) {
+                pom {
+                    name.set(project.name)
+                    description.set("Verifies instrumentation applies to library version")
+                    url.set("https://github.com/newrelic/newrelic-gradle-verify-instrumentation")
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                            distribution.set("repo")
+                        }
                     }
-                }
-                developers {
-                    developer {
-                        id.set("newrelic")
-                        name.set("New Relic")
-                        email.set("opensource@newrelic.com")
+                    developers {
+                        developer {
+                            id.set("newrelic")
+                            name.set("New Relic")
+                            email.set("opensource@newrelic.com")
+                        }
                     }
-                }
-                scm {
-                    url.set("git@github.com:newrelic/newrelic-gradle-verify-instrumentation.git")
-                    connection.set("scm:git:git@github.com:newrelic/newrelic-gradle-verify-instrumentation.git")
+                    scm {
+                        url.set("git@github.com:newrelic/newrelic-gradle-verify-instrumentation.git")
+                        connection.set("scm:git:git@github.com:newrelic/newrelic-gradle-verify-instrumentation.git")
+                    }
                 }
             }
         }
     }
 }
 
-signing {
-    val signingKeyId: String? by project
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    sign(publishing.publications["mavenJava"])
+afterEvaluate {
+    signing {
+        val signingKeyId: String? by project
+        val signingKey: String? by project
+        val signingPassword: String? by project
+        useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        sign(publishing.publications["gradle-verify-instrumentation-pluginPluginMarkerMaven"])
+        sign(publishing.publications["mavenJava"])
+    }
 }


### PR DESCRIPTION
This will publish the missing artifact - Plugin Maven Marker pom - to maven central.  Confirmed with a test publish  and close in sonatype

I updated the version to 3.2-SNAPSHOT.  If this is merged, then a release for `v3.2` can be created. Then, the manner by which the java agent consumes the gradle verifier can be updated to follow the README directions of the verifier.

<img width="686" alt="Screen Shot 2020-07-08 at 7 31 58 AM" src="https://user-images.githubusercontent.com/24482401/86933716-b4210100-c0ef-11ea-85c9-234ee3001e1b.png">
