### PR TITLE
verifies classpath even if no ranges are declared

### DIFF
--- a/src/main/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationAction.java
+++ b/src/main/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationAction.java
@@ -48,13 +48,15 @@ public class AfterEvaluationAction implements Action<Project> {
             return;
         }
 
-        if (options.passesOnly().size() + options.passes().size() == 0) {
-            logger.info("Nothing to do - 'passesOnly' or 'passes' is required.");
-            return;
-        }
+        if(!options.verifyClasspath) {
+            if (options.passesOnly().size() + options.passes().size() == 0) {
+                logger.info("Nothing to do - 'passesOnly' or 'passes' or jar on classpath is required.");
+                return;
+            }
 
-        if (options.passesOnly().size() > 0 == options.passes().size() > 0) {
-            throw new GradleException("'passesOnly' cannot be specified with 'passes'.");
+            if (options.passesOnly().size() > 0 == options.passes().size() > 0) {
+                throw new GradleException("'passesOnly' cannot be specified with 'passes'.");
+            }
         }
 
         // get the repository sources from the user's build.gradle


### PR DESCRIPTION
Fixes #20 

verifies against jar on classpath, even if there is no declared `verifyInstrumentation` range. Confirmed via manual debugging and also output `passes.txt`  in build/verifier

To test, I had to get around the compatibility plugin requiring a `verifyInstrumentation`  range. I commented out the `site` block in the instrumentation build.gradle module. 

```
//site {
//    title 'IBM DB2'
//    type 'Datastore'
//}
```
 