### PR TITLE
Add after evaluation tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testImplementation("org.codehaus.groovy:groovy:2.5.10")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.6.1")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.1")
+    testImplementation("org.mockito:mockito-core:2.28.2")
 }
 
 tasks.test {

--- a/src/main/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationAction.java
+++ b/src/main/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationAction.java
@@ -69,7 +69,7 @@ public class AfterEvaluationAction implements Action<Project> {
         List<RemoteRepository> mavenRepositories = getRepositoriesFunction.apply(project);
 
         // create collection of excludes
-        Set<String> excludedVersions = buildExcludedVersions(options, mavenRepositories);
+        Set<String> excludedVersions = buildExcludedVersions(options, mavenRepositories, MavenClient.INSTANCE);
 
         ProjectTaskFactory taskFactory = new ProjectTaskFactory(project, excludedVersions, logger, destinationDir);
         taskFactory.setPassesFile(options.passesFileName);
@@ -133,12 +133,13 @@ public class AfterEvaluationAction implements Action<Project> {
         }
     }
 
-    private Set<String> buildExcludedVersions(VerifyInstrumentationOptions verifyInstrumentation, List<RemoteRepository> mavenRepositories) {
+    @VisibleForTesting
+    public Set<String> buildExcludedVersions(VerifyInstrumentationOptions verifyInstrumentation, List<RemoteRepository> mavenRepositories, MavenClient mavenClient) {
         Set<String> excludedVersions = new HashSet<>(verifyInstrumentation.excludeRegex());
 
         Set<String> resolvedExclusions = verifyInstrumentation.exclude().stream()
                 .flatMap((String excludeRange) ->
-                        MavenClient.INSTANCE.resolveAvailableVersions(excludeRange, mavenRepositories).stream()
+                        mavenClient.resolveAvailableVersions(excludeRange, mavenRepositories).stream()
                                 .peek(dep -> logger.info("Excluding artifact: " + dep)))
                 .collect(Collectors.toSet());
 

--- a/src/main/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationAction.java
+++ b/src/main/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationAction.java
@@ -5,6 +5,7 @@
 
 package com.newrelic.agent.instrumentation.verify;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.gradle.api.*;
@@ -120,7 +121,8 @@ public class AfterEvaluationAction implements Action<Project> {
         return false;
     }
 
-    private void createProjectDependencyOnAgent(Project project, Object nrAgent) {
+    @VisibleForTesting
+    public void createProjectDependencyOnAgent(Project project, Object nrAgent) {
         project.getConfigurations().create(VERIFIER_TASK_NAME);
         if (nrAgent instanceof File) {
             // allow a local file defined agent

--- a/src/test/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationActionTest.java
+++ b/src/test/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationActionTest.java
@@ -5,7 +5,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownProjectException;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.internal.impldep.org.testng.Assert;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +18,9 @@ import java.util.*;
 import java.util.function.Function;
 
 import static com.newrelic.agent.instrumentation.verify.VerificationPlugin.VERIFIER_TASK_NAME;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.gradle.internal.impldep.org.testng.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 class AfterEvaluationActionTest {
@@ -133,6 +134,6 @@ class AfterEvaluationActionTest {
         //merge sets to produce expected
         resolvedExcludedVersions.addAll(excludeRegex);
 
-        Assert.assertEquals(resolvedExcludedVersions, result);
+        assertEquals(resolvedExcludedVersions, result);
     }
 }

--- a/src/test/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationActionTest.java
+++ b/src/test/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationActionTest.java
@@ -9,6 +9,9 @@ import org.gradle.internal.impldep.org.testng.Assert;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -22,22 +25,30 @@ import static org.mockito.Mockito.*;
 class AfterEvaluationActionTest {
 
     private AfterEvaluationAction testClass;
-    private VerifyInstrumentationOptions mockOptions;
-    private Logger mockLogger;
-    private File mockDestinationDir;
-    private Task mockTask;
-    private Project mockProject;
     private Function<Project, List<RemoteRepository>> getRepositoryFunction;
 
     @BeforeEach
-    void before() {
-        this.mockOptions = mock(VerifyInstrumentationOptions.class);
-        this.mockLogger = mock(Logger.class);
-        this.mockDestinationDir=mock(File.class);
-        this.mockTask = mock(Task.class);
-        this.mockProject = mock(Project.class, RETURNS_DEEP_STUBS);
+    void beforeEach() {
+        MockitoAnnotations.initMocks(this);
         this.getRepositoryFunction = project -> Collections.emptyList();
+        this.testClass = new AfterEvaluationAction(mockOptions, mockTask, mockLogger, mockDestinationDir, getRepositoryFunction);
     }
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    public Project mockProject;
+
+    @Mock
+    public Task mockTask;
+
+    @Mock
+    public File mockDestinationDir;
+
+    @Mock
+    public Logger mockLogger;
+
+    @Mock
+    public VerifyInstrumentationOptions mockOptions;
+
 
     @Test
     void shouldVerifyProjectWithTaskNameVerifyInstrumentation() {
@@ -85,7 +96,6 @@ class AfterEvaluationActionTest {
 
     @Test
     void shouldCreateDependencyOnAgentOfFileType() {
-        AfterEvaluationAction testClass = new AfterEvaluationAction(mockOptions, mockTask, mockLogger, mockDestinationDir, getRepositoryFunction);
         File mockAgent = new File("/agentForTest");
         Project testProject = ProjectBuilder.builder().build();
 
@@ -97,7 +107,6 @@ class AfterEvaluationActionTest {
 
     @Test
     void shouldCreateDependencyOnAgentOfObjectType() {
-        AfterEvaluationAction testClass = new AfterEvaluationAction(mockOptions, mockTask, mockLogger, mockDestinationDir, getRepositoryFunction);
         Dependency mockAgent = mock(Dependency.class);
         Project testProject = ProjectBuilder.builder().build();
 
@@ -109,7 +118,6 @@ class AfterEvaluationActionTest {
 
     @Test
     void shouldBuildExcludedRegexAndVersions() {
-        AfterEvaluationAction testClass = new AfterEvaluationAction(mockOptions, mockTask, mockLogger, mockDestinationDir, getRepositoryFunction);
         MavenClient mockMavenClient = mock(MavenClient.class);
         Set<String> excludeRegex = new HashSet<String>();
         excludeRegex.add("testExcludedRegex:.*(RC|SEC|M)[0-9]*$'");

--- a/src/test/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationActionTest.java
+++ b/src/test/java/com/newrelic/agent/instrumentation/verify/AfterEvaluationActionTest.java
@@ -1,0 +1,109 @@
+package com.newrelic.agent.instrumentation.verify;
+
+import org.eclipse.aether.repository.RemoteRepository;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.UnknownProjectException;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.util.*;
+import java.util.function.Function;
+
+import static com.newrelic.agent.instrumentation.verify.VerificationPlugin.VERIFIER_TASK_NAME;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AfterEvaluationActionTest {
+
+    private AfterEvaluationAction testClass;
+    private VerifyInstrumentationOptions mockOptions;
+    private Logger mockLogger;
+    private File mockDestinationDir;
+    private Task mockTask;
+    private Project mockProject;
+    private Function<Project, List<RemoteRepository>> getRepositoryFunction;
+
+    @BeforeEach
+    void before() {
+        this.mockOptions = mock(VerifyInstrumentationOptions.class);
+        this.mockLogger = mock(Logger.class);
+        this.mockDestinationDir=mock(File.class);
+        this.mockTask = mock(Task.class);
+        this.mockProject = mock(Project.class, RETURNS_DEEP_STUBS);
+        this.getRepositoryFunction = project -> Collections.emptyList();
+    }
+
+    @Test
+    void shouldVerifyProjectWithTaskNameVerifyInstrumentation() {
+        String projectPath = "/pathToProjectBuildFile";
+        List<String> taskNames = new ArrayList<>();
+        taskNames.add(VERIFIER_TASK_NAME);
+        when(mockProject.getGradle().getStartParameter().getTaskNames()).thenReturn(taskNames);
+        when(mockProject.getGradle().getStartParameter().getCurrentDir().getPath()).thenReturn(projectPath);
+        when(mockProject.getProjectDir().getPath()).thenReturn(projectPath);
+
+        assertTrue(AfterEvaluationAction.projectRequiresVerification(mockProject));
+    }
+
+    @Test
+    void shouldVerifyProjectWithProjectPathBeforeTaskName() {
+        String projectPath = "/pathToProject/";
+        List<String> taskNames = new ArrayList<>();
+        taskNames.add(projectPath+VERIFIER_TASK_NAME);
+        when(mockProject.getGradle().getStartParameter().getTaskNames()).thenReturn(taskNames);
+        when(mockProject.project(":"+projectPath).getProjectDir().getPath()).thenReturn(projectPath);
+        when(mockProject.getProjectDir().getPath()).thenReturn(projectPath);
+
+        assertTrue(AfterEvaluationAction.projectRequiresVerification(mockProject));
+    }
+
+    @Test
+    void shouldNotVerifyProjectDueToTaskName() {
+        List<String> taskNames = new ArrayList<>();
+        taskNames.add(VERIFIER_TASK_NAME + "needs to be at end. This won't work.");
+        when(mockProject.getGradle().getStartParameter().getTaskNames()).thenReturn(taskNames);
+
+        assertFalse(AfterEvaluationAction.projectRequiresVerification(mockProject));
+    }
+
+    @Test
+    void shouldNotVerifyProjectWhenNoProjectWithPath() {
+        String projectPath = "/noProjectAtPath";
+        List<String> taskNames = Arrays.asList(projectPath + VERIFIER_TASK_NAME);
+
+        when(mockProject.getGradle().getStartParameter().getTaskNames()).thenReturn(taskNames);
+        when(mockProject.project(":"+projectPath)).thenThrow(new UnknownProjectException("nothing here"));
+
+        assertFalse(AfterEvaluationAction.projectRequiresVerification(mockProject));
+    }
+
+    @Test
+    void shouldCreateDependencyOnAgentOfFileType() {
+        AfterEvaluationAction testClass = new AfterEvaluationAction(mockOptions, mockTask, mockLogger, mockDestinationDir, getRepositoryFunction);
+        File mockAgent = new File("/agentForTest");
+        Project testProject = ProjectBuilder.builder().build();
+
+        testClass.createProjectDependencyOnAgent(testProject, mockAgent);
+
+        assertEquals(1,
+                testProject.getConfigurations().getByName(VERIFIER_TASK_NAME).getDependencies().size());
+    }
+
+    @Test
+    void shouldCreateDependencyOnAgentOfObjectType() {
+        AfterEvaluationAction testClass = new AfterEvaluationAction(mockOptions, mockTask, mockLogger, mockDestinationDir, getRepositoryFunction);
+        Dependency mockAgent = mock(Dependency.class);
+        Project testProject = ProjectBuilder.builder().build();
+
+        testClass.createProjectDependencyOnAgent(testProject, mockAgent);
+
+        assertEquals(1,
+                testProject.getConfigurations().getByName(VERIFIER_TASK_NAME).getDependencies().size());
+    }
+
+}


### PR DESCRIPTION
Adding test coverage for AfterEvaluationAction class. This is not complete yet but felt like its a good point to check in. 

Test coverage is  needed before refactoring and addressing this issue - https://github.com/newrelic/newrelic-gradle-verify-instrumentation/issues/20

See code comments for context